### PR TITLE
Fixes generic dig lookup for multiple values

### DIFF
--- a/src/app/controllers/dns.js
+++ b/src/app/controllers/dns.js
@@ -1,6 +1,5 @@
 // Require Packages
 const express = require('express');
-const dns = require('dns');
 const dig = require('../functions/dig');
 const router = express.Router();
 
@@ -9,32 +8,47 @@ router.get('/favicon.ico', (req, res) => res.status(204));
 
 // Read
 router.get('/', async (req, res) => {
-    return res.status(200).send({
-        message: 'dns'
+    return res.status(404).send({
+        error: 'No domain specified'
     });
 });
 
-router.get('/:domain?', async (req, res) => {
-    try {
-        const { domain } = req.params
-        if (typeof domain === 'undefined')
-            return res.status(400).send({
-                error: '400',
-                message: 'Domain is undefined'
-            });
+router.get('/:domain?/:type?', async (req, res) => {
+        const { domain, type } = req.params
+        let Answer = {}
 
-        dig('A', domain, (response) => {
-            return res.status(200).send({
-                answer: response.Answer
-            });
-        })
-    } catch (err) {
-        console.log(err)
-        return res.status(500).send({
-            error: '500',
-            message: 'Something went wrong'
-        });
-    }
+        if (typeof type == 'undefined'){
+            //If a type isn't specified, default to generic record types: A,AAAA,MX,NS
+            const records = ["A", "AAAA", "MX", "NS"]
+
+            for (const record of records) {
+                Answer[record] = []
+            }
+
+            for (const record of records) {
+                await dig (record, domain, (response) => {
+                    for (const dns_record of response){
+                        Answer[record].push(dns_record.data)
+                    }
+
+                })
+            }
+
+        } else {
+            
+            Answer[type.toUpperCase()] = []
+            await dig (type, domain, (response) => {
+                for (const dns_record of response){
+                    Answer[type.toUpperCase()].push(dns_record.data)
+                }
+            })
+            
+        }
+
+    
+    return res.status(200).send({
+        Answer
+    })
 });
 
 // Export

--- a/src/app/functions/dig.js
+++ b/src/app/functions/dig.js
@@ -1,32 +1,13 @@
-const https = require('https')
-const dnsServer = 'https://dns.google/'
+const axios = require('axios');
 
-function dig(type, domain, callback) {
-    
-    try {
+async function dig(type, domain, callback) {
+    try{
 
-        https.get(`${dnsServer}/resolve?name=${domain}&type=${type}&cd=true`, (ans) => {
-
-            if (ans.statusCode != 200){
-                callback(ans.statusCode)
-
-            } else {
-   
-                let data = '';
-                
-                ans.on('data', (chunk) => {
-                    data += chunk
-                })
-                
-                ans.on('end', () => {
-                    callback(JSON.parse(data))
-                })
-            }
-        })
-
+        const response = await axios.get(`https://dns.google/resolve?name=${domain}&type=${type}`)
+        
+        callback(response.data.Answer)
     } catch (err) {
-        console.log(err)
-        return ({ error: 'Something went wrong' })
+        console.log(err);
     }
 
 }


### PR DESCRIPTION
This does quite a few changes: 
Modifies dns endpoint so it can get a `type` of record
- In case it does not receive one, defaults to a standard set of DNS queries (A, AAAA, MX, NS)
- If it does, do that query only

Output looks like this: 
```
{ Answer: {"A": ["127.0.0.1"] } }
```

Complete overhaul of the `dig` function. 
- Lot less lines of code by using `axios`. We don't really need to handle status codes. 

Also minor requires adjustements. Some stuff was being declared while not needing to be declared. 